### PR TITLE
Support more complex nested validations

### DIFF
--- a/lib/justify.ex
+++ b/lib/justify.ex
@@ -100,6 +100,11 @@ defmodule Justify do
 
   * `:message` - error message, defaults to "has invalid format"
   """
+  @spec validate_format(map, Regex.t(), Keyword.t()) :: Justify.Dataset.t()
+  defdelegate validate_format(dataset, format),
+    to: Justify.Validators.Format,
+    as: :call
+
   @spec validate_format(map, atom, Regex.t(), Keyword.t()) :: Justify.Dataset.t()
   defdelegate validate_format(dataset, field, format, opts \\ []),
     to: Justify.Validators.Format,

--- a/lib/justify.ex
+++ b/lib/justify.ex
@@ -143,6 +143,11 @@ defmodule Justify do
       * “should have at least %{count} item(s)”
       * “should have at most %{count} item(s)”
   """
+  @spec validate_length(map, Keyword.t()) :: Justify.Dataset.t()
+  defdelegate validate_length(dataset, opts),
+    to: Justify.Validators.Length,
+    as: :call
+
   @spec validate_length(map, atom, Keyword.t()) :: Justify.Dataset.t()
   defdelegate validate_length(dataset, field, opts),
     to: Justify.Validators.Length,

--- a/lib/justify.ex
+++ b/lib/justify.ex
@@ -161,6 +161,11 @@ defmodule Justify do
     to: Justify.Validators.Required,
     as: :call
 
+  @spec validate_map(map, atom, Keyword.t()) :: Justify.Dataset.t()
+  defdelegate validate_map(dataset, fields, opts \\ []),
+    to: Justify.Validators.Map,
+    as: :call
+
   @doc """
   Adds an error to the dataset.
 
@@ -169,7 +174,7 @@ defmodule Justify do
   """
   @spec add_error(Justify.Dataset.t(), atom, String.t(), Keyword.t()) :: Justify.Dataset.t()
   def add_error(dataset, field, message, keys \\ []) do
-    put_error(dataset, field, { message, keys })
+    put_error(dataset, field, {message, keys})
   end
 
   @doc false
@@ -177,8 +182,8 @@ defmodule Justify do
     errors =
       dataset
       |> Map.get(:errors)
-      |> Enum.concat([{ field, error }])
+      |> Enum.concat([{field, error}])
 
-    %{ dataset | errors: errors, valid?: false }
+    %{dataset | errors: errors, valid?: false}
   end
 end

--- a/lib/justify/field.ex
+++ b/lib/justify/field.ex
@@ -1,0 +1,11 @@
+defmodule Justify.Field do
+  def value(dataset, field, default \\ "")
+
+  def value(dataset, field, default) when is_map(dataset) do
+    case dataset.data do
+      m when is_map(m) -> Map.get(m, field)
+      l when is_list(l) -> Enum.at(l, field)
+      x -> x
+    end || default
+  end
+end

--- a/lib/justify/validators/format.ex
+++ b/lib/justify/validators/format.ex
@@ -3,10 +3,13 @@ defmodule Justify.Validators.Format do
 
   @default_message "has invalid format"
 
+  def call(dataset, format), do: call(dataset, dataset, format)
+  def call(dataset, format, opts) when is_list(opts), do: call(dataset, dataset, format, opts)
+
   def call(dataset, field, format, opts \\ []) do
     dataset = Justify.Dataset.new(dataset)
 
-    value = Map.get(dataset.data, field)
+    value = Justify.Field.value(dataset, field, "")
 
     message = Keyword.get(opts, :message, @default_message)
 

--- a/lib/justify/validators/length.ex
+++ b/lib/justify/validators/length.ex
@@ -22,7 +22,7 @@ defmodule Justify.Validators.Length do
   def call(dataset, field, opts) do
     dataset = Justify.Dataset.new(dataset)
 
-    value = Map.get(dataset.data, field) || ""
+    value = Justify.Field.value(dataset, field, "")
 
     opts =
       opts

--- a/lib/justify/validators/length.ex
+++ b/lib/justify/validators/length.ex
@@ -19,6 +19,8 @@ defmodule Justify.Validators.Length do
     }
   }
 
+  def call(dataset, opts), do: call(dataset, dataset, opts)
+
   def call(dataset, field, opts) do
     dataset = Justify.Dataset.new(dataset)
 

--- a/lib/justify/validators/map.ex
+++ b/lib/justify/validators/map.ex
@@ -1,0 +1,31 @@
+defmodule Justify.Validators.Map do
+  @moduledoc false
+
+  def call(dataset, field, validator) do
+    dataset = Justify.Dataset.new(dataset)
+    value = Justify.Field.value(dataset, field, nil)
+
+    case validate(value, validator) do
+      [] ->
+        dataset
+
+      errors ->
+        Justify.put_error(dataset, field, errors)
+    end
+  end
+
+  defp validate(map, validator) when is_map(map) do
+    map
+    |> Map.keys()
+    |> Enum.reduce(map, fn key, dataset ->
+      Justify.validate_embed(dataset, key, validator)
+    end)
+    |> Map.get(:errors)
+  end
+
+  defp validate(value, validator) do
+    value
+    |> validator.()
+    |> Map.get(:errors, [])
+  end
+end

--- a/lib/justify/validators/required.ex
+++ b/lib/justify/validators/required.ex
@@ -29,6 +29,6 @@ defmodule Justify.Validators.Required do
   #
 
   defp maybe_trim_value(nil, _does_not_matter), do: nil
-  defp maybe_trim_value(value, true), do: String.trim(value)
+  defp maybe_trim_value(value, true) when is_binary(value), do: String.trim(value)
   defp maybe_trim_value(value, _do_not_trim), do: value
 end

--- a/test/justify_test.exs
+++ b/test/justify_test.exs
@@ -329,6 +329,16 @@ defmodule JustifyTest do
                valid?: false
              } = Justify.validate_format(data, field, ~r/\d/, message: message)
     end
+
+    test "can validate a simple value" do
+      data = "message"
+
+      assert %Justify.Dataset{
+               data: ^data,
+               errors: [{^data, {_, validation: :format}}],
+               valid?: false
+             } = Justify.validate_format(data, ~r/\d/)
+    end
   end
 
   describe "validate_inclusion/4" do

--- a/test/justify_test.exs
+++ b/test/justify_test.exs
@@ -213,6 +213,24 @@ defmodule JustifyTest do
                valid?: true
              } = Justify.validate_embed(data, field, fun)
     end
+
+    test "can validate embedded lists" do
+      data = %{key: ["123", "1"]}
+
+      assert %Justify.Dataset{
+               errors: [
+                 key: [
+                   [
+                     {"1", _}
+                   ]
+                 ]
+               ],
+               valid?: false
+             } =
+               Justify.validate_embed(data, :key, fn d ->
+                 Justify.validate_length(d, min: 2)
+               end)
+    end
   end
 
   describe "validate_exclusion/4" do

--- a/test/justify_test.exs
+++ b/test/justify_test.exs
@@ -736,9 +736,36 @@ defmodule JustifyTest do
 
       assert %Justify.Dataset{
                data: ^data,
-               errors: [{ ^field, { ^message, validation: :required } }],
+               errors: [{^field, {^message, validation: :required}}],
                valid?: false
              } = Justify.validate_required(data, field, message: message)
+    end
+  end
+
+  describe "validate_map/3" do
+    test "validates every key in a map" do
+      field = :name
+
+      data = %{
+        nested: %{
+          one: %{name: "Name"},
+          two: %{name: "N"}
+        }
+      }
+
+      assert %Justify.Dataset{
+               errors: [
+                 {:nested,
+                  [
+                    two: [{^field, _}]
+                  ]}
+               ],
+               valid?: false
+             } =
+               Justify.validate_map(data, :nested, fn v ->
+                 v
+                 |> Justify.validate_length(field, min: 2)
+               end)
     end
   end
 end


### PR DESCRIPTION
Hi!

This adds support for validating for maps with arbitrary keys (like JSON objects with IDs as keys) as well as adds support for length validation of plain values (useful for validating things like every entry in a plain list).

```elixir
%{
  nested: %{
    one: %{name: "Name"},
    two: %{name: "N"}
  }
}
|> Justify.validate_map(data, :nested, fn v ->
  Justify.validate_length(v, :name, min: 2)
end)

# as well as

%{key: ["123", "1"]}
|> Justify.validate_embed(:key, fn d ->
  Justify.validate_length(d, min: 2)
end)


%{key: ["123", "1"]} |> Justify.validate_embed(:key, fn d ->
  Justify.validate_length(d, min: 2)
end)
```

Thanks for a great module!